### PR TITLE
[Feature] 주요 도메인 엔티티 및 열거형 구현 (User, Artist, Reservation 등)

### DIFF
--- a/src/main/java/com/starmeet/starmeet/StarmeetApplication.java
+++ b/src/main/java/com/starmeet/starmeet/StarmeetApplication.java
@@ -2,12 +2,13 @@ package com.starmeet.starmeet;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class StarmeetApplication {
 
-	public static void main(String[] args) {
-		SpringApplication.run(StarmeetApplication.class, args);
-	}
-
+  public static void main(String[] args) {
+    SpringApplication.run(StarmeetApplication.class, args);
+  }
 }

--- a/src/main/java/com/starmeet/starmeet/domain/artist/Artist.java
+++ b/src/main/java/com/starmeet/starmeet/domain/artist/Artist.java
@@ -1,0 +1,54 @@
+package com.starmeet.starmeet.domain.artist;
+
+import com.starmeet.starmeet.domain.user.User;
+import com.starmeet.starmeet.global.common.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import java.time.LocalDate;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 아티스트 엔티티 - 아티스트 전용 정보 관리
+ * User 엔티티와 1:1 관계
+ */
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class Artist extends BaseEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @OneToOne(fetch = FetchType.LAZY)
+  @JoinColumn(nullable = false, unique = true)
+  private User user;
+
+  @Column(nullable = false, length = 50)
+  private String stageName;
+
+  @Column(length = 50)
+  private String agency;
+
+  private String profileImageUrl;
+
+  private LocalDate debutDate;
+
+  @Column(length = 1000)
+  private String description;
+
+  @Column(nullable = false)
+  private Boolean isVerified;
+}

--- a/src/main/java/com/starmeet/starmeet/domain/reservation/PaymentStatus.java
+++ b/src/main/java/com/starmeet/starmeet/domain/reservation/PaymentStatus.java
@@ -1,0 +1,20 @@
+package com.starmeet.starmeet.domain.reservation;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 결제 상태를 정의
+ */
+@Getter
+@RequiredArgsConstructor
+public enum PaymentStatus {
+
+  PENDING("결제 대기", "결제가 대기 중인 상태"),
+  COMPLETED("결제 완료", "결제가 정상적으로 완료된 상태"),
+  FAILED("결제 실패", "결제가 실패한 상태"),
+  REFUNDED("환불 완료", "결제가 환불된 상태");
+
+  private final String displayName; // 화면에 표시될 한글명
+  private final String description; // 상태 설명
+}

--- a/src/main/java/com/starmeet/starmeet/domain/reservation/Reservation.java
+++ b/src/main/java/com/starmeet/starmeet/domain/reservation/Reservation.java
@@ -1,0 +1,67 @@
+package com.starmeet.starmeet.domain.reservation;
+
+import com.starmeet.starmeet.domain.session.VideoSession;
+import com.starmeet.starmeet.domain.user.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 예약 엔티티 - 팬이 아티스트 세션에 대한 예약 정보
+ */
+@Entity
+@Table(uniqueConstraints = { // 동일 세션에 대한 중복 예약 방지
+    @UniqueConstraint(
+        name = "uk_reservation_session_user",
+        columnNames = {"session_id", "user_id"}
+    )
+})
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class Reservation {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(nullable = false)
+  private VideoSession session;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(nullable = false)
+  private User user; // 예약한 사용자
+
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false)
+  private ReservationStatus status;
+
+  @Column(nullable = false)
+  private LocalDateTime reservedAt;
+
+  private LocalDateTime cancelledAt;
+
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false)
+  private PaymentStatus paymentStatus;
+
+  @Column(length = 100)
+  private String paymentId;  // 외부 결제 시스템의 결제 ID
+}

--- a/src/main/java/com/starmeet/starmeet/domain/reservation/ReservationStatus.java
+++ b/src/main/java/com/starmeet/starmeet/domain/reservation/ReservationStatus.java
@@ -1,0 +1,21 @@
+package com.starmeet.starmeet.domain.reservation;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 예약 상태를 정의
+ */
+@Getter
+@RequiredArgsConstructor
+public enum ReservationStatus {
+
+  PENDING("대기중", "예약 신청 후 처리 대기 상태"),
+  CONFIRMED("확정", "예약이 확정된 상태"),
+  CANCELLED("취소", "예약이 취소된 상태"),
+  COMPLETED("완료", "영상통화가 완료된 상태"),
+  NO_SHOW("미참석", "예약 시간에 참석하지 않은 상태");
+
+  private final String displayName; // 화면에 표시될 한글명
+  private final String description; // 상태 설명
+}

--- a/src/main/java/com/starmeet/starmeet/domain/session/SessionStatus.java
+++ b/src/main/java/com/starmeet/starmeet/domain/session/SessionStatus.java
@@ -1,0 +1,20 @@
+package com.starmeet.starmeet.domain.session;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 영상통화 세션 상태를 정의
+ */
+@Getter
+@RequiredArgsConstructor
+public enum SessionStatus {
+
+  SCHEDULED("예약됨", "세션이 예약되어 대기 중인 상태"),
+  IN_PROGRESS("진행 중", "세션이 현재 진행 중인 상태"),
+  COMPLETED("완료", "세션이 정상적으로 완료된 상태"),
+  CANCELLED("취소", "세션이 취소된 상태");
+
+  private final String displayName; // 화면에 표시될 한글명
+  private final String description; // 상태 설명
+}

--- a/src/main/java/com/starmeet/starmeet/domain/session/VideoSession.java
+++ b/src/main/java/com/starmeet/starmeet/domain/session/VideoSession.java
@@ -1,0 +1,68 @@
+package com.starmeet.starmeet.domain.session;
+
+import com.starmeet.starmeet.domain.artist.Artist;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 영상통화 세션 엔티티 - 아티스트가 생성하는 팬미팅 세션 정보
+ */
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class VideoSession {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY) // 아티스트와 N:1 관계
+  @JoinColumn(nullable = false)
+  private Artist artist;
+
+  @Column(nullable = false)
+  private LocalDate sessionDate;
+
+  @Column(nullable = false)
+  private LocalTime startTime;
+
+  @Column(nullable = false)
+  private LocalTime endTime;
+
+  @Column(nullable = false)
+  private Integer durationMinutes; // 1인당 통화 시간(분)
+
+  @Column(nullable = false)
+  private Integer maxParticipants; // 최대 예약 가능 인원
+
+  @Column(nullable = false)
+  private Integer currentParticipants; // 현재 예약 인원
+
+  @Column(nullable = false, precision = 10, scale = 2)
+  private BigDecimal price; // 예약 가격
+
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false)
+  private SessionStatus status;
+
+  @Column(nullable = false)
+  private String description;
+}

--- a/src/main/java/com/starmeet/starmeet/domain/user/User.java
+++ b/src/main/java/com/starmeet/starmeet/domain/user/User.java
@@ -1,0 +1,46 @@
+package com.starmeet.starmeet.domain.user;
+
+import com.starmeet.starmeet.global.common.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 사용자 엔티티 - 팬과 아티스트의 공통 사용자 정보 관리
+ */
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class User extends BaseEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(nullable = false, unique = true, length = 100)
+  private String email;
+
+  @Column(nullable = false, length = 60)
+  private String password;
+
+  @Column(nullable = false, length = 20)
+  private String nickname;
+
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false)
+  private UserRole role;
+
+  @Column(nullable = false)
+  private Boolean isActive;
+}

--- a/src/main/java/com/starmeet/starmeet/domain/user/UserRole.java
+++ b/src/main/java/com/starmeet/starmeet/domain/user/UserRole.java
@@ -1,0 +1,18 @@
+package com.starmeet.starmeet.domain.user;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 사용자 역할을 정의
+ */
+@Getter
+@RequiredArgsConstructor
+public enum UserRole {
+
+  USER("ROLE_USER", "일반 사용자"),
+  ARTIST("ROLE_ARTIST", "아티스트");
+
+  private final String authority;   // Spring Security에서 사용할 권한명
+  private final String description; // 역할 설명
+}

--- a/src/main/java/com/starmeet/starmeet/global/common/BaseEntity.java
+++ b/src/main/java/com/starmeet/starmeet/global/common/BaseEntity.java
@@ -1,0 +1,28 @@
+package com.starmeet.starmeet.global.common;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+/**
+ * 모든 엔티티의 기본 클래스
+ * 공통 필드(생성일시, 수정일시)를 관리
+ */
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+
+  @CreatedDate
+  @Column(nullable = false, updatable = false)
+  private LocalDateTime createdAt;
+
+  @LastModifiedDate
+  @Column(nullable = false)
+  private LocalDateTime updatedAt;
+}


### PR DESCRIPTION
## 📌 관련 이슈
- close #1 

## 📝 변경 사항
### AS-IS
- 프로젝트 초기 상태로, 주요 도메인 엔티티 및 열거형 미구현 상태

### TO-BE
- BaseTimeEntity 공통 엔티티 구현 (생성 및 수정 시간 자동 처리)
- JPA Auditing 설정 (@EnableJpaAuditing 설정 포함)
- User 엔티티: 사용자 이메일, 비밀번호, 권한(UserRole) 필드 포함
- UserRole 열거형: 사용자 권한 구분
- Artist 엔티티: 아티스트 이름 및 프로필 관련 필드
- VideoSession 엔티티: 아티스트와 매핑되는 세션 정보
- SessionStatus 열거형: 세션 상태 관리
- Reservation 엔티티: 사용자, 세션, 예약 시간 등 포함
- ReservationStatus, PaymentStatus 열거형으로 예약 및 결제 상태 관리
- 복합 유니크 제약 조건: 동일 세션에 대해 동일 사용자의 중복 예약 방지

## 🔍 테스트
- [ ] 테스트 코드 작성
- [ ] API 테스트
- [x] 로컬 테스트
  - DB 테이블 생성 확인

## ✅ 체크리스트
- [x] main 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?